### PR TITLE
Fix item duplication bug

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -252,7 +252,8 @@ minetest.register_abm( {
 	end
 } )
 
--- Make sure that all stacks in the 'recipe' inv count 1 item. Bigger stacks result in item duplication, see issue#14
+-- Make sure that all stacks in the 'recipe' inv count 1 item.
+-- Bigger stacks result in item duplication, see issue#14
 minetest.register_lbm({
 	name = "crafting_bench:cleanup_rec_inv",
 	label = "remove multiple-item-stacks from recipe inv",
@@ -262,12 +263,12 @@ minetest.register_lbm({
 		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
 		for i, item in ipairs(inv:get_list("rec")) do
-			if not item:is_empty() then
-				inv:set_stack("rec", i, item:peek_item())
-				local leftover = inv:add_item("dst", item:to_string())
-				if not leftover:is_empty() then
-					minetest.log("action", "[crafting_bench] deleting leftover " .. item:to_string() .. " from recipe inv at " .. minetest.pos_to_string(pos))
-				end
+			-- Limit to stack size 1 (or keep empty)
+			inv:set_stack("rec", i, item:peek_item())
+			local leftover = inv:add_item("dst", item)
+			if not leftover:is_empty() then
+				minetest.log("action", "[crafting_bench] deleting leftover " ..
+					item:to_string() .. " from recipe inv at " .. minetest.pos_to_string(pos))
 			end
 		end
 	end

--- a/init.lua
+++ b/init.lua
@@ -126,6 +126,7 @@ minetest.register_node("crafting_bench:workbench",{
 		end
 
 		if to_list == "dst" then
+			-- Only allow to take from the output
 			return 0
 		elseif to_list == "rec" then
 			local meta = minetest.get_meta(pos)
@@ -133,8 +134,14 @@ minetest.register_node("crafting_bench:workbench",{
 			local stack = inv:get_stack(from_list, from_index)
 			stack:set_count(1)
 			inv:set_stack(to_list, to_index, stack)
+
+			if from_list == "rec" then
+				-- For convenience: emulate movement instead of duplication
+				inv:set_stack(from_list, from_index, "")
+			end
 			return 0
 		elseif from_list == "rec" then
+			-- Remove recipe stack
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
 			inv:set_stack(from_list, from_index, "")

--- a/init.lua
+++ b/init.lua
@@ -114,13 +114,6 @@ minetest.register_node("crafting_bench:workbench",{
 		return inv:is_empty("src") and inv:is_empty("rec") and inv:is_empty("dst")
 	end,
 	on_blast = function(pos) end,
-	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
-		local meta = minetest.get_meta(pos)
-		local inv = meta:get_inventory()
-		local stack = inv:get_stack(to_list, to_index)
-		stack:set_count(count)
-		minetest.log("action", player:get_player_name().." moves "..stack:to_string().." in workbench at "..minetest.pos_to_string(pos))
-	end,
 	on_metadata_inventory_put = function(pos, listname, index, stack, player)
 		minetest.log("action", player:get_player_name().." put "..stack:to_string().." in workbench at "..minetest.pos_to_string(pos))
 	end,
@@ -259,6 +252,7 @@ minetest.register_abm( {
 	end
 } )
 
+-- Make sure that all stacks in the 'recipe' inv count 1 item. Bigger stacks result in item duplication, see issue#14
 minetest.register_lbm({
 	name = "crafting_bench:cleanup_rec_inv",
 	label = "remove multiple-item-stacks from recipe inv",
@@ -268,7 +262,7 @@ minetest.register_lbm({
 		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
 		for i, item in ipairs(inv:get_list("rec")) do
-			if not item:is_empty() and item:get_count() > 1 then
+			if not item:is_empty() then
 				inv:set_stack("rec", i, item:peek_item())
 				local leftover = inv:add_item("dst", item:to_string())
 				if not leftover:is_empty() then


### PR DESCRIPTION
Fixes #14 
Uses some code from https://github.com/fluxionary/minetest-crafting_bench, @fluxionary thankfully allowed this :).

- Improve item movement log messages
- Only allow one item per stack in the recipe field
- Adding a recipe doesn't take the items anymore
- Add LBM to move leftover items from >1 items big stacks to the craft output